### PR TITLE
Add `dumpjson` command and `dump_stream` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,29 @@ Globally (not recommended):
     sudo pip install encrypit
     ```
 
+## Dump Packets as JSON
+
+### Python API
+
+    ```python
+    from encryptit.dump_json import dump_stream
+
+    with open('encrypted.gpg', 'rb') as f:
+        print(dump_stream(f))
+    ```
+
+### Command-line
+
+    ```shell
+    $ encryptit dumpjson encrypted.gpg
+    ```
+
+### GnuPG Equivalent (ish)
+
+    ```shell
+    $ gpg --list-packets encrypted.json
+    ```
+
 ## Encrypt a File
 
 ### Python API

--- a/encryptit/__init__.py
+++ b/encryptit/__init__.py
@@ -1,4 +1,1 @@
 __version__ = '0.0.1'
-
-from pkgutil import extend_path
-__path__ = extend_path(__path__, __name__)

--- a/encryptit/__main__.py
+++ b/encryptit/__main__.py
@@ -1,0 +1,36 @@
+# encoding: utf-8
+
+"""
+EncryptIt
+
+  Usage:
+    encryptit dumpjson <file.gpg>
+    encryptit -h | --help
+    encryptit --version
+
+  Options:
+    -h --help   Show this screen.
+"""
+
+from __future__ import unicode_literals
+
+from docopt import docopt
+
+from .cli import dump_json
+
+
+def main():
+    from .__init__ import __version__
+
+    version_string = (
+        'EncryptIt {0}\n'
+        'Copyright © 2015 Paul M Furley <paul@paulfurley.com>\n'
+        'License AGPLv3: GNU Affero Public License version 3 '
+        '<http://gnu.org/licenses/agpl.html>\n'
+        'This is free software: you are free to change and redistribute it.\n'
+        'There is NO WARRANTY, to the extend permitted by law.').format(
+            __version__)
+
+    arguments = docopt(__doc__, version=version_string)
+    if arguments['dumpjson'] is True:
+        dump_json(arguments['<file.gpg>'])

--- a/encryptit/cli/__init__.py
+++ b/encryptit/cli/__init__.py
@@ -1,0 +1,1 @@
+from .dump_json import dump_json

--- a/encryptit/cli/dump_json.py
+++ b/encryptit/cli/dump_json.py
@@ -1,0 +1,8 @@
+import sys
+
+from ..dump_json import dump_stream
+
+
+def dump_json(filename):
+    with open(filename, 'rb') as f:
+        sys.stdout.write(dump_stream(f) + '\n')

--- a/encryptit/dump_json.py
+++ b/encryptit/dump_json.py
@@ -1,0 +1,28 @@
+import json
+
+from .compat import OrderedDict
+from .openpgp_message import OpenPGPMessage
+
+
+def dump_stream(f, indent=4):
+    message = OpenPGPMessage.from_stream(f)
+    return json.dumps(message, indent=indent, cls=OpenPGPJsonEncoder)
+
+
+class OpenPGPJsonEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, bytes):
+            return self.serialize_bytes(obj)
+
+        if getattr(obj, 'serialize'):
+            return obj.serialize()
+
+        return repr(obj)
+
+    @staticmethod
+    def serialize_bytes(some_bytes):
+        return OrderedDict([
+            ('octets', ':'.join(['{:02x}'.format(byte)
+                                 for byte in some_bytes])),
+            ('length', len(some_bytes)),
+        ])

--- a/encryptit/tests/dump_json/test_dump_stream.py
+++ b/encryptit/tests/dump_json/test_dump_stream.py
@@ -1,0 +1,18 @@
+import json
+from os.path import join as pjoin
+
+from encryptit.dump_json import dump_stream
+
+from ..sample_files import SAMPLE_DIR, SAMPLE_FILES
+
+
+def test_dump_stream_produces_valid_json():
+    for short_filename, full_filename in SAMPLE_FILES:
+        yield assert_produces_valid_json, short_filename
+
+
+def assert_produces_valid_json(filename):
+    with open(pjoin(SAMPLE_DIR, filename), 'rb') as f:
+        json_string = dump_stream(f)
+
+    assert isinstance(json.loads(json_string), dict)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pycrypto==2.6.1
 enum34==1.0.4
+docopt==0.6.2

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,9 @@ setup(
     install_requires=[],
     packages=['encryptit'],
     entry_points={
+        'console_scripts': [
+            'encryptit=encryptit.__main__:main',
+        ],
     },
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',


### PR DESCRIPTION
Add `dumpjson` command and `dump_stream` API
    
These create an `OpenPGPMessage` and the new `dump_json.py` specifies a
lightweight JSON encoder which mostly delgates to the `serialize` method
on `OpenPGPMessage` and children.
    
- Add a `__main__.py` file with `encryptit` entry point
- Use `docopt` to handle command line arguments
- New `dump_json.py` module and `cli/dump_json.py` command line API user
