### PR TITLE
Fix byte-ordering, add strict checking

### DIFF
--- a/encryptit/compat/struct_unpack.py
+++ b/encryptit/compat/struct_unpack.py
@@ -16,12 +16,14 @@ def is_version_2_6():
 
 def _unpack_v26(format_string, byte_array):
     _validate_byte_array_type(byte_array)
+    _validate_format_string(format_string)
 
     return struct.unpack(format_string, str(byte_array))
 
 
 def _unpack_v27_v3x(format_string, byte_array):
     _validate_byte_array_type(byte_array)
+    _validate_format_string(format_string)
 
     return struct.unpack(format_string, byte_array)
 
@@ -31,5 +33,16 @@ def _validate_byte_array_type(byte_array):
         raise TypeError(
             'Can only unpack from `bytearray` not: {0}'.format(
                 type(byte_array)))
+
+
+def _validate_format_string(format_string):
+    """
+    Ensure that either little endian (<) or big endian (>) is specified.
+    """
+    if not format_string.startswith('<') and not format_string.startswith('>'):
+        raise ValueError(
+            'Byte order must be specified. See '
+            'https://docs.python.org/3/library/struct.html'
+            '#byte-order-size-and-alignment')
 
 struct_unpack = _unpack_v26 if is_version_2_6() else _unpack_v27_v3x

--- a/encryptit/decoder.py
+++ b/encryptit/decoder.py
@@ -154,12 +154,12 @@ class OldPacketHeader(PacketHeader):
         elif length_type == 1:  # 2-octet length
             self.header_length = 3
             two_octets = read_bytes(f, 2, MalformedPacketError)
-            self.body_length = struct_unpack('H', two_octets)[0]
+            self.body_length = struct_unpack('>H', two_octets)[0]
 
         elif length_type == 2:  # 4-octet length
             self.header_length = 5
             four_octets = read_bytes(f, 4, MalformedPacketError)
-            self.body_length = struct_unpack('I', four_octets)[0]
+            self.body_length = struct_unpack('>I', four_octets)[0]
 
         else:
             raise NotImplementedError(
@@ -213,7 +213,7 @@ class NewPacketHeader(PacketHeader):
         elif first_octet == 255:         # 4.2.2.3. Five-Octet Lengths
             self.header_length = 6
             four_octets = read_bytes(f, 4, MalformedPacketError)
-            self.body_length = struct_unpack('I', four_octets)[0]
+            self.body_length = struct_unpack('>I', four_octets)[0]
 
         else:
             raise NotImplementedError(

--- a/encryptit/tests/compat/test_struct_unpack.py
+++ b/encryptit/tests/compat/test_struct_unpack.py
@@ -1,4 +1,6 @@
-from nose.tools import assert_equal, assert_raises, assert_is_instance
+from nose.tools import assert_equal, assert_raises
+
+from ..test_utils import assert_is_instance
 from encryptit.compat import struct_unpack
 
 # See https://docs.python.org/2/library/struct.html

--- a/encryptit/tests/compat/test_struct_unpack.py
+++ b/encryptit/tests/compat/test_struct_unpack.py
@@ -4,11 +4,17 @@ from encryptit.compat import struct_unpack
 # See https://docs.python.org/2/library/struct.html
 
 TESTS = [
-    # (0x01 << 24) + (0x02 << 16) + (0x03 << 8) + 0x01
+    # (0x01 << 24) + (0x02 << 16) + (0x03 << 8) + 0x04
     (bytearray([1, 2, 3, 4]), '>I', (16909060,)),
+
+    # (0x04 << 24) + (0x03 << 16) + (0x02 << 8) + 0x01
+    (bytearray([1, 2, 3, 4]), '<I', (67305985,)),
 
     # (0x01 << 8) + 0x02 and (0x03 << 8) + (0x04)
     (bytearray([1, 2, 3, 4]), '>HH', (258, 772)),
+
+    # (0x02 << 8) + (0x01) and (0x04 << 8) + 0x03
+    (bytearray([1, 2, 3, 4]), '<HH', (513, 1027)),
 
     (bytearray([1, 2, 3, 4]), '>BBBB', (1, 2, 3, 4)),
 ]

--- a/encryptit/tests/decoder/test_consume_header.py
+++ b/encryptit/tests/decoder/test_consume_header.py
@@ -134,11 +134,11 @@ def _make_old_format_header(packet_tag, body_length):
     elif 0xFF < body_length <= 0xFFFF:
         length_type_bits = 0b00000001  # 1 means 2-octet length
         # https://docs.python.org/2/library/struct.html#format-characters
-        length_octets = struct.pack('H', body_length)
+        length_octets = struct.pack('>H', body_length)
 
     elif 0xFFFF < body_length <= 0xFFFFFFFF:
         length_type_bits = 0b00000010  # 2 means 4-octet length
-        length_octets = struct.pack('I', body_length)
+        length_octets = struct.pack('>I', body_length)
 
     else:
         raise ValueError(body_length)
@@ -169,7 +169,7 @@ def _make_new_format_header(packet_tag, body_length):
 
     elif 8383 < body_length <= 0xFFFFFFFF:  # five-octet length
         # https://tools.ietf.org/html/rfc4880#section-4.2.2.3
-        length_octets = bytearray([255]) + struct.pack('I', body_length)
+        length_octets = bytearray([255]) + struct.pack('>I', body_length)
 
     packet_first_octet = NEW_OCTET_0 | tag_bits
     return bytearray([packet_first_octet]) + length_octets

--- a/encryptit/tests/test_utils/__init__.py
+++ b/encryptit/tests/test_utils/__init__.py
@@ -1,0 +1,1 @@
+from .assert_is_instance_func import assert_is_instance

--- a/encryptit/tests/test_utils/assert_is_instance_func.py
+++ b/encryptit/tests/test_utils/assert_is_instance_func.py
@@ -1,0 +1,5 @@
+try:
+    import assert_is_instance
+except ImportError:
+    def assert_is_instance(obj, cls, msg=None):
+        assert isinstance(obj, cls), msg


### PR DESCRIPTION
- Add validation function for `struct_unpack` to require specifying `>` or
`<`
- Update all uses of `struct_unpack`

See https://tools.ietf.org/html/rfc4880#section-3.1 (Scalar Numbers) which
specifies:

```
   Scalar numbers are unsigned and are always stored in big-endian
   format.  Using n[k] to refer to the kth octet being interpreted, the
   value of a two-octet scalar is ((n[0] << 8) + n[1]).  The value of a
   four-octet scalar is ((n[0] << 24) + (n[1] << 16) + (n[2] << 8) +
   n[3]).
```
So we generally need to use `>` for big-endian numbers (my platform default
is little-endian :( )

By default `struct.unpack` assumes "native" byte order - ie platform
dependent. That's not very helpful when OpenPGP packets are a defined byte
order.

https://docs.python.org/2/library/struct.html#byte-order-size-and-alignment

I don't believe there's a useful case at the moment for using `unpack`
*without* specifying byte order (and this sloppiness allowed bug #5 to slip
through).

Fixes #5