### PR TITLE
Update and add tests for `PacketLocation`

### DIFF
--- a/encryptit/decoder.py
+++ b/encryptit/decoder.py
@@ -36,8 +36,7 @@ def find_packets(f):
         yield PacketLocation(
             header_start=f.tell() - header.header_length,
             body_start=f.tell(),
-            body_length=header.body_length,
-            packet_type=header.packet_type)
+            body_length=header.body_length)
 
         seek_relative(f, header.body_length)
 

--- a/encryptit/openpgp_message.py
+++ b/encryptit/openpgp_message.py
@@ -35,11 +35,25 @@ class OpenPGPMessage(object):
 
 
 class PacketLocation(namedtuple(
-        'PacketLocation', 'header_start,body_start,body_length,packet_type')):
+        'PacketLocation', 'header_start,body_start,body_length')):
     def serialize(self):
         return OrderedDict([
             ('header_start', self.header_start),
+            ('header_length', self.header_length),
+            ('header_end', self.header_end),
             ('body_start', self.body_start),
             ('body_length', self.body_length),
-            ('packet_type', self.packet_type),
+            ('body_end', self.body_end),
         ])
+
+    @property
+    def header_length(self):
+        return self.body_start - self.header_start
+
+    @property
+    def header_end(self):
+        return self.body_start
+
+    @property
+    def body_end(self):
+        return self.body_start + self.body_length

--- a/encryptit/tests/decoder/test_find_packets.py
+++ b/encryptit/tests/decoder/test_find_packets.py
@@ -6,81 +6,65 @@ from ..sample_files import SAMPLE_FILES, SAMPLE_DIR
 
 from encryptit.decoder import find_packets
 from encryptit.openpgp_message import PacketLocation
-from encryptit.packets import PacketType
+
 
 EXPECTED_LOCATIONS = {
     'gpg_1.4.16_symmetric_simples2k.gpg': [
         PacketLocation(
             header_start=0,
             body_start=2,
-            body_length=4,
-            packet_type=PacketType.SymmetricKeyEncryptedSessionKeyPacket),
+            body_length=4),
         PacketLocation(
             header_start=6,
             body_start=8,
-            body_length=59,
-            packet_type=PacketType
-            .SymmetricEncryptedandIntegrityProtectedDataPacket),
+            body_length=59),
     ],
     'gpg_2.0.22_symmetric_simples2k.gpg': [
         PacketLocation(
             header_start=0,
             body_start=2,
-            body_length=4,
-            packet_type=PacketType.SymmetricKeyEncryptedSessionKeyPacket),
+            body_length=4),
         PacketLocation(
             header_start=6,
             body_start=8,
-            body_length=59,
-            packet_type=PacketType
-            .SymmetricEncryptedandIntegrityProtectedDataPacket),
+            body_length=59),
     ],
     'gpg_1.4.16_symmetric_saltedanditerateds2k.gpg': [
         PacketLocation(
             header_start=0,
             body_start=2,
-            body_length=13,
-            packet_type=PacketType.SymmetricKeyEncryptedSessionKeyPacket),
+            body_length=13),
         PacketLocation(
             header_start=15,
             body_start=17,
-            body_length=72,
-            packet_type=PacketType
-            .SymmetricEncryptedandIntegrityProtectedDataPacket),
+            body_length=72),
     ],
     'gpg_2.0.22_symmetric_saltedanditerated2k.gpg': [
         PacketLocation(
             header_start=0,
             body_start=2,
-            body_length=13,
-            packet_type=PacketType.SymmetricKeyEncryptedSessionKeyPacket),
+            body_length=13),
         PacketLocation(
             header_start=15,
             body_start=17,
-            body_length=59,
-            packet_type=PacketType
-            .SymmetricEncryptedandIntegrityProtectedDataPacket),
+            body_length=59),
     ],
     'gpg_1.4.16_asymmetric_and_symmetric_simples2k.gpg': [
 
         PacketLocation(
             header_start=0,
             body_start=3,
-            body_length=524,
-            packet_type=PacketType.PublicKeyEncryptedSessionKeyPacket),
+            body_length=524),
 
         PacketLocation(
             header_start=527,
             body_start=529,
-            body_length=46,
-            packet_type=PacketType.SymmetricKeyEncryptedSessionKeyPacket),
+            body_length=46),
 
         PacketLocation(
             header_start=575,
             body_start=577,
-            body_length=65,
-            packet_type=PacketType
-            .SymmetricEncryptedandIntegrityProtectedDataPacket),
+            body_length=65),
 
     ],
 

--- a/encryptit/tests/openpgp_message/test_packet_location.py
+++ b/encryptit/tests/openpgp_message/test_packet_location.py
@@ -1,0 +1,42 @@
+import json
+
+from nose.tools import assert_equal
+
+from encryptit.openpgp_message import PacketLocation
+from encryptit.dump_json import OpenPGPJsonEncoder
+
+PACKET_LOCATION = PacketLocation(
+    header_start=10,
+    body_start=12,
+    body_length=8)
+
+
+def test_packet_location_header_length_field():
+    assert_equal(2, PACKET_LOCATION.header_length)
+
+
+def test_packet_location_header_end_field():
+    assert_equal(12, PACKET_LOCATION.header_end)
+
+
+def test_packet_location_body_end_field():
+    assert_equal(20, PACKET_LOCATION.body_end)
+
+
+def test_packet_location_serialize():
+    # convert to JSON then back again in order to compare as python objects -
+    # less picky than comparing as strings.
+
+    as_json = json.dumps(PACKET_LOCATION.serialize(), cls=OpenPGPJsonEncoder)
+    back_to_data = json.loads(as_json)
+
+    assert_equal(
+        {
+            'header_start': 10,
+            'header_length': 2,
+            'header_end': 12,
+            'body_start': 12,
+            'body_length': 8,
+            'body_end': 20,
+        },
+        back_to_data)


### PR DESCRIPTION
- Remove packet type from `PacketLocation`. It's inappropriate - the
 packet location should be concerned only about the location of the
 packet within a wider stream. It shouldn't be concerned with the
 decoding of the packet.
- Implement calculated fields. `PacketLocation` is constructed with
 `header_start`, `body_start`, `body_length` and that's what is stores.
 It's helpful to be able to access `header_length`, `header_end` and
 `body_end` too, so those are now calculated fields.
- Tests for calculcated fields and `serialize` method