### PR TITLE
Fix JSON encoding of `PacketLocation`

### DIFF
--- a/encryptit/dump_json.py
+++ b/encryptit/dump_json.py
@@ -19,6 +19,15 @@ class OpenPGPJsonEncoder(json.JSONEncoder):
 
         return repr(obj)
 
+    def encode(self, obj):
+        # If a builtin type provides a `serialize` method, use that instead of
+        # the default serialisation, eg. namedtuple
+
+        if getattr(obj, 'serialize', None):
+            obj = obj.serialize()
+
+        return super(OpenPGPJsonEncoder, self).encode(obj)
+
     @staticmethod
     def serialize_bytes(some_bytes):
         return OrderedDict([

--- a/encryptit/tests/openpgp_message/test_packet_location.py
+++ b/encryptit/tests/openpgp_message/test_packet_location.py
@@ -23,11 +23,11 @@ def test_packet_location_body_end_field():
     assert_equal(20, PACKET_LOCATION.body_end)
 
 
-def test_packet_location_serialize():
+def test_packet_location_json_serializing():
     # convert to JSON then back again in order to compare as python objects -
     # less picky than comparing as strings.
 
-    as_json = json.dumps(PACKET_LOCATION.serialize(), cls=OpenPGPJsonEncoder)
+    as_json = json.dumps(PACKET_LOCATION, cls=OpenPGPJsonEncoder)
     back_to_data = json.loads(as_json)
 
     assert_equal(


### PR DESCRIPTION
Because it derives from a `namedtuple`, the JSON serializer already knew
how to serialize it (as a JSON array).

This modification to `OpenPGPJsonEncoder` means that *any* object providing
a `serialize` method will be serialized according to the output of that
(rather than the builtin approach)