### PR TITLE
Tweak JSON encoder

### DIFF
--- a/encryptit/dump_json.py
+++ b/encryptit/dump_json.py
@@ -17,7 +17,7 @@ class OpenPGPJsonEncoder(json.JSONEncoder):
         if getattr(obj, 'serialize', None):
             return obj.serialize()
 
-        return repr(obj)
+        return super(OpenPGPJsonEncoder, self).default(obj)
 
     def encode(self, obj):
         # If a builtin type provides a `serialize` method, use that instead of

--- a/encryptit/dump_json.py
+++ b/encryptit/dump_json.py
@@ -14,7 +14,7 @@ class OpenPGPJsonEncoder(json.JSONEncoder):
         if isinstance(obj, bytes):
             return self.serialize_bytes(obj)
 
-        if getattr(obj, 'serialize'):
+        if getattr(obj, 'serialize', None):
             return obj.serialize()
 
         return repr(obj)


### PR DESCRIPTION
- JSON encoder should explode on unknown types, rather than dimly returning their `repr`
- Don't fail if no `serialize` method