### PR TITLE
Support `bytearray` in custom JSON encoder

### DIFF
--- a/encryptit/dump_json.py
+++ b/encryptit/dump_json.py
@@ -12,7 +12,7 @@ def dump_stream(f, output_stream, indent=4):
 
 class OpenPGPJsonEncoder(json.JSONEncoder):
     def default(self, obj):
-        if isinstance(obj, bytes):
+        if isinstance(obj, bytearray):
             return self.serialize_bytes(obj)
 
         if getattr(obj, 'serialize', None):
@@ -32,7 +32,7 @@ class OpenPGPJsonEncoder(json.JSONEncoder):
     @staticmethod
     def serialize_bytes(some_bytes):
         return OrderedDict([
-            ('octets', ':'.join(['{:02x}'.format(byte)
+            ('octets', ':'.join(['{0:02x}'.format(byte)
                                  for byte in some_bytes])),
             ('length', len(some_bytes)),
         ])

--- a/encryptit/tests/dump_json/test_encoder.py
+++ b/encryptit/tests/dump_json/test_encoder.py
@@ -5,11 +5,6 @@ from nose.tools import assert_equal
 from encryptit.dump_json import OpenPGPJsonEncoder
 
 
-def test_encode_bytes():
-    result = json.dumps(bytes(bytearray([0x01, 0x08])), cls=OpenPGPJsonEncoder)
-    assert_equal('{"octets": "01:08", "length": 2}', result)
-
-
 def test_encode_bytearray():
     result = json.dumps(bytearray([0x01, 0x08]), cls=OpenPGPJsonEncoder)
     assert_equal('{"octets": "01:08", "length": 2}', result)

--- a/encryptit/tests/dump_json/test_encoder.py
+++ b/encryptit/tests/dump_json/test_encoder.py
@@ -1,0 +1,15 @@
+import json
+
+from nose.tools import assert_equal
+
+from encryptit.dump_json import OpenPGPJsonEncoder
+
+
+def test_encode_bytes():
+    result = json.dumps(bytes(bytearray([0x01, 0x08])), cls=OpenPGPJsonEncoder)
+    assert_equal('{"octets": "01:08", "length": 2}', result)
+
+
+def test_encode_bytearray():
+    result = json.dumps(bytearray([0x01, 0x08]), cls=OpenPGPJsonEncoder)
+    assert_equal('{"octets": "01:08", "length": 2}', result)


### PR DESCRIPTION
Add test for JSON encoding `bytes` and `bytearray`