### PR TITLE
Factor out `bytearray_or_str` helper

### DIFF
--- a/encryptit/compat/bytearray_or_str.py
+++ b/encryptit/compat/bytearray_or_str.py
@@ -1,0 +1,31 @@
+"""
+In Python 2.6 some things like `struct.unpack`, `hashlib.sha1().update`
+cannot take a `bytearray`.
+
+The `bytearray` seems the most portable container so we use it extensively in
+the codebase.
+
+This compatibility function converts it to a `str` on Python 2.6 only.
+"""
+
+import sys
+
+
+def bytearray_or_str(byte_array):
+    _validate_got_bytearray(byte_array)
+
+    if _is_version_2_6():
+        return str(byte_array)
+    else:
+        return byte_array
+
+
+def _validate_got_bytearray(byte_array):
+    if not isinstance(byte_array, bytearray):
+        raise TypeError(
+            'Can only accept `bytearray` not: {0}'.format(type(byte_array)))
+
+
+def _is_version_2_6():
+    (major, minor, _, _, _) = sys.version_info
+    return major == 2 and minor == 6

--- a/encryptit/compat/struct_unpack.py
+++ b/encryptit/compat/struct_unpack.py
@@ -1,34 +1,19 @@
 """
 Python 2.6 `struct.unpack` differs from 2.7, 3.x as it cannot accept a
-`bytearray` argument. The `bytearray` seems the most portable container
-so the solution here is to provide a Python-2.6 specific line which
-converts the `bytearray` into `str`.
+`bytearray` argument.
+
+We use the `bytearray_or_str` helper to get round this.
 """
 
-import sys
 import struct
 
-
-def is_version_2_6():
-    (major, minor, _, _, _) = sys.version_info
-    return major == 2 and minor == 6
+from .bytearray_or_str import bytearray_or_str
 
 
 def struct_unpack(format_string, byte_array):
-    _validate_byte_array_type(byte_array)
     _validate_format_string(format_string)
 
-    if is_version_2_6():
-        byte_array = str(byte_array)
-
-    return struct.unpack(format_string, byte_array)
-
-
-def _validate_byte_array_type(byte_array):
-    if not isinstance(byte_array, bytearray):
-        raise TypeError(
-            'Can only unpack from `bytearray` not: {0}'.format(
-                type(byte_array)))
+    return struct.unpack(format_string, bytearray_or_str(byte_array))
 
 
 def _validate_format_string(format_string):

--- a/encryptit/tests/compat/test_struct_unpack.py
+++ b/encryptit/tests/compat/test_struct_unpack.py
@@ -48,7 +48,7 @@ def test_non_bytearray_types_raise_type_error():
 
 def assert_raises_for_type(type_):
     data = type_([1, 2, 3, 4])
-    assert_raises(TypeError, lambda: struct_unpack('I', data))
+    assert_raises(TypeError, lambda: struct_unpack('>I', data))
 
 
 def test_disallowed_byte_order_characters():


### PR DESCRIPTION
We currently use it for Python 2.6 compatibility with `struct.unpack` but
we're going to need it shortly for the `hashlib.foo().update(..)` functions.